### PR TITLE
update to react-native 0.34 notation for activity result

### DIFF
--- a/android/src/main/java/com/applicaster/RNYoutubePlayer/YoutubePlayerModule.java
+++ b/android/src/main/java/com/applicaster/RNYoutubePlayer/YoutubePlayerModule.java
@@ -61,5 +61,14 @@ public class YoutubePlayerModule extends ReactContextBaseJavaModule implements A
             promise.resolve(map);
         }
     }
-}
 
+    public void onActivityResult(Activity activity, int requestCode, int resultCode, Intent data) {
+        Log.d(TAG, "on activity result");
+        if (requestCode == YOUTUBE_PLAYER_ACTIVITY && resultCode == Activity.RESULT_CANCELED) {
+            Log.d(TAG, "promise resolved");
+            WritableMap map = Arguments.createMap();
+            map.putString("state", STATE_STOPPED);
+            promise.resolve(map);
+        }
+    }
+}


### PR DESCRIPTION
React to change of `onActivityResult` signature around 0.31-0.33.
